### PR TITLE
Passing controller to guard instead of current_user and request

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -17,8 +17,7 @@ class SwitchUserController < ApplicationController
     end
 
     def available?
-      current_user = send("#{SwitchUser.provider}_current_user")
-      SwitchUser.controller_guard.call(current_user, request)
+      SwitchUser.controller_guard.call(self)
     end
 
     def devise_handle(params)

--- a/app/helpers/switch_user_helper.rb
+++ b/app/helpers/switch_user_helper.rb
@@ -32,6 +32,6 @@ module SwitchUserHelper
       user = send("current_#{scope}")
       break if user
     end
-    SwitchUser.view_guard.call(user, request)
+    SwitchUser.view_guard.call(self)
   end
 end

--- a/lib/switch_user.rb
+++ b/lib/switch_user.rb
@@ -28,9 +28,9 @@ module SwitchUser
   self.available_users_names = { :user => :email }
 
   mattr_accessor :controller_guard
-  self.controller_guard = lambda { |current_user, request| Rails.env.development? }
+  self.controller_guard = lambda { |controller| Rails.env.development? }
   mattr_accessor :view_guard
-  self.view_guard = lambda { |current_user, request| Rails.env.development? }
+  self.view_guard = lambda { |controller| Rails.env.development? }
 
   mattr_accessor :redirect_path
   self.redirect_path = lambda { |request, params| request.env["HTTP_REFERER"] ? :back : root_path }


### PR DESCRIPTION
Hi Richard,

How do you feel about changing the parameter definitions for the controller and view guards? I ran into a problem that I could not solve otherwise.

My project has two sets of devise users, `AdminUsers` and `Users`, and a single visitor can be signed in as both simultaneously. In order to give only `AdminUsers` the ability to switch to different `Users`, I needed to check the `current_admin_user` in my guard. 

The only solution I could think of was to modify the guards to take the `controller`, then check for `controller.current_admin_user`.
