### PR TITLE
integration with active admin

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -26,7 +26,7 @@ class SwitchUserController < ApplicationController
     if params[:scope_identifier].blank?
       provider.logout_all
     else
-      params[:scope_identifier] =~ /^([^_]+)_(.*)$/
+      params[:scope_identifier] =~ /^(.*)_([^_]+)$/
       scope, identifier = $1, $2
 
       user = SwitchUser::UserLoader.new(scope, identifier).load


### PR DESCRIPTION
Hi, 
this pull request aims to fix issue with the integration of switch_user with the activeadmin engine. 
So basically, the problem is that by default the activeadmin user's identifier is admin_user.
As described in issue #8 (Unable to parse scope_identifier that contains '_' in scope name) - this would cause an exception when try to switch to the admin user.
