### PR TITLE
Fix calling guards after argument refactoring

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -19,7 +19,7 @@ class SwitchUserController < ApplicationController
   end
 
   def available?
-    SwitchUser.controller_guard.call(provider.current_user, request)
+    SwitchUser.controller_guard(provider.current_user, request)
   end
 
   def handle_request(params)

--- a/app/helpers/switch_user_helper.rb
+++ b/app/helpers/switch_user_helper.rb
@@ -39,7 +39,7 @@ module SwitchUserHelper
 
   def available?
     user = provider.current_users_without_scope.first
-    SwitchUser.view_guard.call(user, request)
+    SwitchUser.view_guard(user, request)
   end
 
   def provider


### PR DESCRIPTION
The last commit broke calling guards. (Specs were  failing, too.)
