### PR TITLE
Change Gemfile source to secure gemcutter.org.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://gemcutter.org'
 
 # Specify your gem's dependencies in switch_user.gemspec
 gemspec


### PR DESCRIPTION
The `source :gemcutter` is deprecated because HTTP requests are insecure.
