### PR TITLE
available_users_names also accepts procs

### DIFF
--- a/app/helpers/switch_user_helper.rb
+++ b/app/helpers/switch_user_helper.rb
@@ -35,7 +35,7 @@ module SwitchUserHelper
   end
 
   def tag_label(user, name)
-    user.send(name)
+    name.respond_to?(:call) ? name.call(user) : user.send(name)
   end
 
   def available?


### PR DESCRIPTION
@lcowell It would be super cool if I could specify a Proc as well as a Symbol for my select label names. e.g.

``` ruby
# config/initializers/switch_user.rb
config.available_users_names = { :user => proc { |u| "#{u.role_name} - #{u.email}" } }
```

Is this good to merge?
