### PR TITLE
Rails 4.1 removed the deprecated .scoped method.

### DIFF
--- a/lib/switch_user/user_set.rb
+++ b/lib/switch_user/user_set.rb
@@ -48,10 +48,10 @@ module SwitchUser
         if scoped.respond_to?(:scoped)
           scoped
         else
-          user_class.scoped
+          user_class.respond_to?(:scoped) ? user_class.scoped : user_class.all
         end
       else
-        user_class.scoped
+        user_class.respond_to?(:scoped) ? user_class.scoped : user_class.all
       end
     end
     class Record < Struct.new(:id, :label, :scope)


### PR DESCRIPTION
The recommendation that I found is to use `.all`, which should return an `ActiveRecord::Relation`.
