### PR TITLE
Restore original user after sorcery logout

### DIFF
--- a/lib/switch_user/provider/sorcery.rb
+++ b/lib/switch_user/provider/sorcery.rb
@@ -10,7 +10,23 @@ module SwitchUser
       end
 
       def logout(scope = nil)
+        if SwitchUser.switch_back
+          save_original_user_identifier
+        end
+
         @controller.logout
+
+        restore_original_user_identifier
+      end
+
+      def save_original_user_identifier
+        @original_user_scope_identifier = @controller.session[:original_user_scope_identifier]
+      end
+
+      def restore_original_user_identifier
+        if @original_user_scope_identifier
+          @controller.session[:original_user_scope_identifier] = @original_user_scope_identifier
+        end
       end
 
       def current_user(scope = nil)

--- a/spec/provider/sorcery_spec.rb
+++ b/spec/provider/sorcery_spec.rb
@@ -4,6 +4,7 @@ require 'switch_user/provider/sorcery'
 class SorceryController < TestController
   def logout
     @user = nil
+    reset_session
   end
 
   def auto_login(user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,8 @@ class TestController
   def session
     @session_hash ||= {}
   end
+
+  def reset_session
+    @session_hash = {}
+  end
 end

--- a/spec/support/provider.rb
+++ b/spec/support/provider.rb
@@ -33,7 +33,7 @@ shared_examples_for "a provider" do
   it "can lock the original user, allowing us to change current_user" do
     provider.login(user)
     provider.remember_current_user(true)
-    provider.login(other_user)
+    provider.login_exclusive(other_user, scope: "user")
 
     provider.original_user.should == user
     provider.current_user.should == other_user


### PR DESCRIPTION
Sorcery calls reset_session on [logout](https://github.com/NoamB/sorcery/blob/master/lib/sorcery/controller.rb#L55) which wipes the whole session including `original_user_scope_identifier`, which breaks the switch-back feature.

This change is more specific for sorcery. If other providers do the same this should be moved to `login_exclusive` method to affect all providers.
