### PR TITLE
Allow routes to be disabled

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
-Rails.application.routes.draw do
-  get :switch_user, :to => 'switch_user#set_current_user'
-  get 'switch_user/remember_user', :to => 'switch_user#remember_user'
+if SwitchUser.generate_routes
+  Rails.application.routes.draw do
+    get :switch_user, :to => 'switch_user#set_current_user'
+    get 'switch_user/remember_user', :to => 'switch_user#remember_user'
+  end
 end

--- a/lib/generators/switch_user/install/templates/switch_user.rb
+++ b/lib/generators/switch_user/install/templates/switch_user.rb
@@ -1,4 +1,7 @@
 SwitchUser.setup do |config|
+  # have switch user add routes to its controllers automatically
+  # config.generate_routes = true
+
   # provider may be :devise, :authlogic, :clearance, :restful_authentication, :sorcery, or :session
   config.provider = :devise
 

--- a/lib/switch_user.rb
+++ b/lib/switch_user.rb
@@ -12,6 +12,7 @@ module SwitchUser
 
   class InvalidScope < Exception; end
 
+  mattr_accessor :generate_routes
   mattr_accessor :provider
   mattr_accessor :available_users
   mattr_accessor :available_users_identifiers
@@ -52,6 +53,7 @@ module SwitchUser
   end
 
   def self.reset_config
+    self.generate_routes = true
     self.provider = :devise
     self.available_users = { :user => lambda { User.all } }
     self.available_users_identifiers = { :user => :id }


### PR DESCRIPTION
I wanted to be able to have more customization over how this gem worked.

I wanted to be able to override the controller so that I could perform 'remember me' and 'switch user' in one action, but I also wanted to namespace the controller into my Users namespace.

This patch makes it really easy to disable the routes switch_user generates for you so you can just plug your own route in.

(See #55)
