### PR TITLE
Devise provider- don't store sign_in details

### DIFF
--- a/lib/switch_user/provider/devise.rb
+++ b/lib/switch_user/provider/devise.rb
@@ -7,7 +7,7 @@ module SwitchUser
       end
 
       def login(user, scope = :user)
-        @warden.set_user(user, :scope => scope)
+        @warden.session_serializer.store(user, scope)
       end
 
       def logout(scope = :user)


### PR DESCRIPTION
* closes https://github.com/flyerhzm/switch_user/issues/67
* warden#set_user sets current_sign_in_at, last_sign_in_at,
current_sign_in_ip, sign_in_count, current_sign_in_ip, last_sign_in_ip
* use SessionSerialializer#store to bypass the updating of these columns
* thanks https://github.com/rajagopals/switch_user/commit/7437c5c3b039df1c7f9acd83bf672971a02e3f28