### PR TITLE
security :guardsman:

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -19,7 +19,7 @@ class SwitchUserController < ApplicationController
   private
 
   def developer_modes_only
-    render :text => "Permission Denied", :status => 403 unless available?
+    raise ActionController::RoutingError.new('Do not try to hack us.') unless available?
   end
 
   def available?


### PR DESCRIPTION
It would be more secure to show a basic 404 page and not to reveal you are using _switch_user_ gem. What do you think?