### PR TITLE
Devise provider- don't store sign_in details

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ switch_user action should be allowed.
 
 This feature should be used with extreme caution because of the security implications. This is especially true in a production environment.
 
+## Contributing
+
+#### Run tests
+
+`bundle exec rspec spec`
+
 ## Credit
 
 Copyright © 2010 - 2015 Richard Huang (flyerhzm@gmail.com), released under the MIT license

--- a/lib/switch_user/provider/devise.rb
+++ b/lib/switch_user/provider/devise.rb
@@ -7,7 +7,7 @@ module SwitchUser
       end
 
       def login(user, scope = :user)
-        @warden.set_user(user, :scope => scope)
+        @warden.session_serializer.store(user, scope)
       end
 
       def logout(scope = :user)

--- a/spec/provider/devise_spec.rb
+++ b/spec/provider/devise_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 require 'switch_user/provider/devise'
 
+class FakeWardenSessionSerializer
+  attr_accessor :user_hash
+
+
+  def store(user, scope)
+    return unless user
+    user_hash[scope] = user
+  end
+
+end
+
 class FakeWarden
   attr_reader :user_hash
 
@@ -11,6 +22,12 @@ class FakeWarden
   def set_user(user, args)
     scope = args.fetch(:scope, :user)
     @user_hash[scope] = user
+  end
+
+  def session_serializer
+    serializer = FakeWardenSessionSerializer.new
+    serializer.user_hash = @user_hash
+    serializer
   end
 
   def user(scope)


### PR DESCRIPTION
* re-implement e6147fb (reverted in d18b453)
* closes flyerhzm/switch_user#67
* warden#set_user sets current_sign_in_at, last_sign_in_at,
current_sign_in_ip, sign_in_count, current_sign_in_ip, last_sign_in_ip
* use SessionSerialializer#store to bypass the updating of these columns
* fix tests

Obviously the tests are mocked.  Before merging **I recommend testing this for yourself against the real devise provider**