### PR TITLE
DataSource#find_scope_id bug fixes

### DIFF
--- a/lib/switch_user/data_source.rb
+++ b/lib/switch_user/data_source.rb
@@ -30,7 +30,10 @@ module SwitchUser
     end
 
     def find_scope_id(scope_id)
-      user = loader.call.find_by identifier => scope_id.delete("#{scope}_")
+      scope_regexp = /\A#{scope}_/
+      return unless scope_id =~ scope_regexp
+
+      user = loader.call.find_by identifier => scope_id.sub(scope_regexp, '')
       Record.new(user, self)
     end
   end


### PR DESCRIPTION
1. Use String#sub, not String#delete to remove scope str from scope_id str
  - [String#delete](http://ruby-doc.org/core-2.2.0/String.html#method-i-delete) is a strange method that should probably be avoided in most cases :)

2. Don't attempt to query db if scope str isn't in scope_id str