### PR TITLE
Use User.scoped when Rails.version < 4 (do not merge!)

### DIFF
--- a/lib/generators/switch_user/install/templates/switch_user.rb
+++ b/lib/generators/switch_user/install/templates/switch_user.rb
@@ -5,7 +5,11 @@ SwitchUser.setup do |config|
   # available_users is a hash,
   # key is the model name of user (:user, :admin, or any name you use),
   # value is a block that return the users that can be switched.
-  config.available_users = { :user => lambda { User.all } }
+  if Rails.version.to_i >= 4
+    config.available_users = { :user => lambda { User.all } }
+  else
+    config.available_users = { :user => lambda { User.scoped } }
+  end
 
   # available_users_identifiers is a hash,
   # keys in this hash should match a key in the available_users hash

--- a/lib/switch_user.rb
+++ b/lib/switch_user.rb
@@ -53,7 +53,11 @@ module SwitchUser
 
   def self.reset_config
     self.provider = :devise
-    self.available_users = { :user => lambda { User.all } }
+    if Rails.version.to_i >= 4
+      self.available_users = { :user => lambda { User.all } }
+    else
+      self.available_users = { :user => lambda { User.scoped } }
+    end
     self.available_users_identifiers = { :user => :id }
     self.available_users_names = { :user => :email }
     self.guard_class = "SwitchUser::LambdaGuard"


### PR DESCRIPTION
Sorry, I tried it but couldn't make it work.

On your gem, 'bundle exec rspec spec' works, but Rails.version = 4.2.5
I edited gemspec to require ActiveRecord 3.2.21, and this forced Rails.version to 3.2.21
but that 'bundle exec rspec spec' gives this error.

````
/home/ace/.rvm/gems/ruby-2.2.1/gems/activesupport-3.2.21/lib/active_support/values/time_zone.rb:270: warning: circular argument reference - now
/home/ace/Documents/602_Rails_3/switch_user/spec/support/application.rb:62:in `<top (required)>': uninitialized constant ActiveRecord (NameError)
	from /home/ace/Documents/602_Rails_3/switch_user/spec/spec_helper.rb:3:in `require'
````

I then forked the gem and made the two changes in the pull request.
The tests still succeed when Rails.version=4.2.5
but when integrated in my App, it gives the following error:

````
 ArgumentError in Clients#index
Showing /xxxx/app/views/inline_forms/_header.html.erb where line #16 raised:
comparison of Array with Array failed
````

As you see, I am confused and not good enough to help you out with this.

An extra problem is that I use switch_user in development only, and that the initializer throws errors in production, probably solvable with some Rails.env.development?

Thanks for the help, and for a great gem.

It's best not to merge this pull request.