### PR TITLE
fix selected_user_of_helper bug

### DIFF
--- a/app/helpers/switch_user_helper.rb
+++ b/app/helpers/switch_user_helper.rb
@@ -3,17 +3,21 @@ module SwitchUserHelper
   def switch_user_select
     return unless available?
 
-    if provider.current_user
-      selected_user = "user_#{provider.current_user.id}"
-    else
-      selected_user = nil
-    end
+    selected_user = nil
 
     grouped_options_container = {}.tap do |h|
       SwitchUser.all_users.each do |record|
         scope = record.is_a?(SwitchUser::GuestRecord) ? :Guest : record.scope.to_s.capitalize
         h[scope] ||= []
         h[scope] << [record.label, record.scope_id]
+
+        if selected_user.nil?
+          unless record.is_a?(SwitchUser::GuestRecord)
+            if provider.current_user?(record.user, record.scope)
+              selected_user = record.scope_id
+            end
+          end
+        end
       end
     end
 

--- a/lib/switch_user/provider/base.rb
+++ b/lib/switch_user/provider/base.rb
@@ -55,6 +55,11 @@ module SwitchUser
       def clear_original_user
         @controller.session.delete(:original_user_scope_identifier)
       end
+
+      def current_user?(user, scope = :user)
+        current_user(scope) == user
+      end
+
     end
   end
 end

--- a/spec/provider/devise_spec.rb
+++ b/spec/provider/devise_spec.rb
@@ -100,4 +100,14 @@ RSpec.describe SwitchUser::Provider::Devise do
       expect(provider.current_users_without_scope).to eq [user]
     end
   end
+
+  describe "#current_user?" do
+    it "logs the user in" do
+      user = double(:user)
+      provider.login(user, :user)
+
+      expect(provider.current_user?(user, :user)).to eq true
+      expect(provider.current_user?(user, :admin)).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Hi

When I use `config.available_users = { :user => lambda { User.all }, :admin => lambda { Admin.all } }` and switch to an admin, that select option cannot selected.

Please review and merge :)
