### PR TITLE
Update switch_user_controller.rb

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -1,5 +1,5 @@
 class SwitchUserController < ApplicationController
-  before_filter :developer_modes_only
+  before_action :developer_modes_only
 
   def set_current_user
     handle_request(params)


### PR DESCRIPTION
before_filter is deprecated and will  removed in Rails 5.1.