### PR TITLE
Fix for Rails 5 undefined method `back_url'

### DIFF
--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -4,11 +4,19 @@ class SwitchUserController < ApplicationController
   def set_current_user
     handle_request(params)
 
-    redirect_to(SwitchUser.redirect_path.call(request, params))
+    if Rails.version.to_i >= 5
+      redirect_back(fallback_location: root_path)
+    else
+      redirect_to(SwitchUser.redirect_path.call(request, params))
+    end
   end
 
   def remember_user
-    redirect_to(SwitchUser.redirect_path.call(request, params))
+    if Rails.version.to_i >= 5
+      redirect_back(fallback_location: root_path)
+    else
+      redirect_to(SwitchUser.redirect_path.call(request, params))
+    end
   end
 
   private

--- a/app/controllers/switch_user_controller.rb
+++ b/app/controllers/switch_user_controller.rb
@@ -4,18 +4,20 @@ class SwitchUserController < ApplicationController
   def set_current_user
     handle_request(params)
 
-    if Rails.version.to_i >= 5
+    redirect_path = SwitchUser.redirect_path.call(request, params)
+    if Rails.version.to_i >= 5 && redirect_path == :back
       redirect_back(fallback_location: root_path)
     else
-      redirect_to(SwitchUser.redirect_path.call(request, params))
+      redirect_to(redirect_path)
     end
   end
 
   def remember_user
-    if Rails.version.to_i >= 5
+    redirect_path = SwitchUser.redirect_path.call(request, params)
+    if Rails.version.to_i >= 5 && redirect_path == :back
       redirect_back(fallback_location: root_path)
     else
-      redirect_to(SwitchUser.redirect_path.call(request, params))
+      redirect_to(redirect_path)
     end
   end
 

--- a/spec/controllers/switch_user_controller_spec.rb
+++ b/spec/controllers/switch_user_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SwitchUserController, type: :controller do
     it "redirects the user to the specified location" do
       SwitchUser.redirect_path = ->(_,_) { "/path" }
       allow(controller).to receive(:available?).and_return(true)
-      get :set_current_user, scope_identifier: "user_1"
+      get :set_current_user, params: {scope_identifier: "user_1"}
 
       expect(response).to redirect_to("/path")
     end
@@ -52,18 +52,18 @@ RSpec.describe SwitchUserController, type: :controller do
     it "can remember the current user" do
       expect(provider).to receive(:remember_current_user).with(true)
 
-      get :remember_user, remember: "true"
+      get :remember_user, params: {remember: "true"}
     end
     it "can forget the current user" do
       expect(provider).to receive(:remember_current_user).with(false)
 
-      get :remember_user, remember: "false"
+      get :remember_user, params: {remember: "false"}
     end
     it "does nothing if switch_back is not enabled" do
       SwitchUser.switch_back = false
       expect(provider).not_to receive(:remember_current_user)
 
-      get :remember_user, remember: "true"
+      get :remember_user, params: {remember: "true"}
     end
   end
 end

--- a/spec/integration/switch_user_spec.rb
+++ b/spec/integration/switch_user_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe "Using SwitchUser", type: :request do
 
     it "can switch back to a different user through remember_user endpoint" do
       # login
-      post "/login", id: user.id
+      post "/login", params: {id: user.id}
       follow_redirect!
 
       # have SwitchUser remember us
-      get "/switch_user/remember_user", remember: true
+      get "/switch_user/remember_user", params: {remember: true}
       expect(session["original_user_scope_identifier"]).to be_present
 
       # check that we can switch to another user
@@ -52,17 +52,17 @@ RSpec.describe "Using SwitchUser", type: :request do
       expect(session["user_id"]).to eq user.id
 
       # check that we can be un-remembered
-      get "/switch_user/remember_user", remember: false
+      get "/switch_user/remember_user", params: {remember: false}
       expect(session["original_user"]).to be_nil
     end
 
     it "can switch back to a different user without hitting remember_user endpoint" do
       # login
-      post "/login", :id => user.id
+      post "/login", params: {:id => user.id}
       follow_redirect!
 
       # check that we can switch to another user
-      get "/switch_user?scope_identifier=user_#{other_user.id}", :remember => true
+      get "/switch_user?scope_identifier=user_#{other_user.id}", params: {:remember => true}
       expect(session["user_id"]).to eq other_user.id
       expect(session["original_user_scope_identifier"]).to_not be_nil
 
@@ -75,7 +75,7 @@ RSpec.describe "Using SwitchUser", type: :request do
       expect(session["user_id"]).to eq user.id
 
       # check that we can be un-remembered
-      get "/switch_user/remember_user", :remember => false
+      get "/switch_user/remember_user", params: {:remember => false}
       expect(session["original_user"]).to be_nil
     end
   end

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -30,15 +30,27 @@ class DummyController < ApplicationController
   before_action :require_user, only: :protected
 
   def authenticated
-    render text: current_user.inspect
+    if Rails.version.to_i >= 5
+      render plain: current_user.inspect
+    else
+      render text: current_user.inspect
+    end
   end
 
   def open
-    render text: view_context.switch_user_select
+    if Rails.version.to_i >= 5
+      render plain: view_context.switch_user_select
+    else
+      render text: view_context.switch_user_select
+    end
   end
 
   def protected
-    render text: view_context.switch_user_select
+    if Rails.version.to_i >= 5
+      render plain: view_context.switch_user_select
+    else
+      render text: view_context.switch_user_select
+    end
   end
 end
 


### PR DESCRIPTION
After updated to Rails 5.1, I got this exception:
`undefined method back_url'`

Rails 5 has redirect_back, instead of redirect_to :back.