### PR TITLE
Respect identifier when storing original_user

### DIFF
--- a/lib/switch_user/provider/base.rb
+++ b/lib/switch_user/provider/base.rb
@@ -39,7 +39,8 @@ module SwitchUser
 
       def original_user=(user)
         user_type       = user.class.to_s.underscore
-        user_identifier = "#{user_type}_#{user.id}"
+        column_name     = SwitchUser.available_users_identifiers[user_type.to_sym]
+        user_identifier = "#{user_type}_#{user.send(column_name)}"
 
         @controller.session[:original_user_scope_identifier] = user_identifier
       end

--- a/spec/integration/switch_user_spec.rb
+++ b/spec/integration/switch_user_spec.rb
@@ -78,5 +78,64 @@ RSpec.describe "Using SwitchUser", type: :request do
       get "/switch_user/remember_user", params: { :remember => false }
       expect(session["original_user"]).to be_nil
     end
+
+    context "when non-default identifier" do
+      before do
+        SwitchUser.available_users_identifiers = { user: :email }
+      end
+
+      after do
+        SwitchUser.available_users_identifiers = { user: :id }
+      end
+
+      it "can switch back to a different user through remember_user endpoint" do
+        # login
+        post "/login", params: { id: user.id }
+        follow_redirect!
+
+        # have SwitchUser remember us
+        get "/switch_user/remember_user", params: { remember: true }
+        expect(session["original_user_scope_identifier"]).to be_present
+
+        # check that we can switch to another user
+        get "/switch_user?scope_identifier=user_#{other_user.email}"
+        expect(session["user_id"]).to eq other_user.id
+
+        # logout
+        get "/logout"
+        expect(session["user_id"]).to be_nil
+
+        # check that we can still switch to another user
+        get "/switch_user?scope_identifier=user_#{user.email}"
+        expect(session["user_id"]).to eq user.id
+
+        # check that we can be un-remembered
+        get "/switch_user/remember_user", params: { remember: false }
+        expect(session["original_user"]).to be_nil
+      end
+
+      it "can switch back to a different user without hitting remember_user endpoint" do
+        # login
+        post "/login", params: { :id => user.id }
+        follow_redirect!
+
+        # check that we can switch to another user
+        get "/switch_user?scope_identifier=user_#{other_user.email}", params: { :remember => true }
+        expect(session["user_id"]).to eq other_user.id
+        expect(session["original_user_scope_identifier"]).to_not be_nil
+
+        # logout
+        get "/logout"
+        expect(session["user_id"]).to be_nil
+
+        # check that we can still switch to another user
+        get "/switch_user?scope_identifier=user_#{user.email}"
+        expect(session["user_id"]).to eq user.id
+
+        # check that we can be un-remembered
+        get "/switch_user/remember_user", params: { :remember => false }
+        expect(session["original_user"]).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
When using an identifier other than `:id`, remembering original user uses the wrong column