### PR TITLE
Add license field to gemspec

### DIFF
--- a/switch_user.gemspec
+++ b/switch_user.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Richard Huang', 'Luke Cowell']
   s.email       = ['flyerhzm@gmail.com']
+  s.license     = 'MIT'
   s.homepage    = 'http://rubygems.org/gems/switch_user'
   s.summary     = 'Easily switch current user to speed up development'
   s.description = 'Easily switch current user to speed up development'


### PR DESCRIPTION
This adds the license field to the gemspec matching the license already found in the repo to make it easier to automatically verify application license usage.