### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/switch_user.gemspec
+++ b/switch_user.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = 'Easily switch current user to speed up development'
 
   s.required_rubygems_version = '>= 1.3.6'
-  s.rubyforge_project         = 'switch_user'
 
   s.add_development_dependency 'actionpack'
   s.add_development_dependency 'activerecord'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436