### PR TITLE
Fix zeitwerk autloading issue

### DIFF
--- a/lib/switch_user/rails.rb
+++ b/lib/switch_user/rails.rb
@@ -3,8 +3,10 @@
 module SwitchUser
   class Engine < Rails::Engine
     initializer 'switch_user.view' do
-      ActiveSupport.on_load(:action_view) do
-        include SwitchUserHelper
+      config.to_prepare do
+        ActiveSupport.on_load(:action_view) do
+          include SwitchUserHelper
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes: https://github.com/flyerhzm/switch_user/issues/124

Hi! This is a small fix for autoloading switch_user in zeitwerk autoloading mode. It just makes sure that autoloaded `SwitchUserHelper` is loaded after the initialization process. I haven't added explicit requires because of the file structure of the project, didn't really won't to break encapsulation of `app` and `lib` folder by using requires between each one