### PR TITLE
Fixed relative_url_root behaviour

### DIFF
--- a/app/views/switch_user/_widget.html.erb
+++ b/app/views/switch_user/_widget.html.erb
@@ -1,4 +1,4 @@
 <% if SwitchUser.switch_back %>
-  <%= check_box_tag "remember_user", "remember_user", provider.original_user.present?, onchange: "location.href = '#{ActionController::Base.relative_url_root || '/'}switch_user/remember_user?remember=' + encodeURIComponent(this.checked)" %>
+  <%= check_box_tag "remember_user", "remember_user", provider.original_user.present?, onchange: "location.href = '#{ActionController::Base.relative_url_root}/switch_user/remember_user?remember=' + encodeURIComponent(this.checked)" %>
 <% end %>
-<%= select_tag "switch_user_identifier", option_tags, onchange: "location.href = '#{ActionController::Base.relative_url_root || '/'}switch_user?scope_identifier=' + encodeURIComponent(this.options[this.selectedIndex].value)", class: classes, style: styles %>
+<%= select_tag "switch_user_identifier", option_tags, onchange: "location.href = '#{ActionController::Base.relative_url_root}/switch_user?scope_identifier=' + encodeURIComponent(this.options[this.selectedIndex].value)", class: classes, style: styles %>


### PR DESCRIPTION
switch_user select Widget doesn't correctly resolve relative_url_roots.
In the rails guides it is proposed to use RAILS_RELATIVE_URL_ROOT=/relative with a leading, but not a trailing slash.
(see https://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root)
When using this with switch_user it will generate a select with `onchange="location.href = '/relativeswitch_user?scope_identifier...`. The callback url `/relativeswitch_user` will crash.

This PR fixes this and correctly inserts /relative/switch_user as callback. Also works correctly without RAILS_RELATIVE_URL_ROOT set.